### PR TITLE
모달 추상화

### DIFF
--- a/src/components/SelectInput.tsx
+++ b/src/components/SelectInput.tsx
@@ -3,17 +3,17 @@ import { IonIcon, IonInput, IonItem } from '@ionic/react';
 import ArrowDownIcon from '../assets/svgs/arrow-down.svg';
 
 type Props = {
+  id: string;
   label: string;
   value: string;
-  openModal: () => void;
 };
 
-const SelectInput = ({ label, value, openModal }: Props) => {
+const SelectInput = ({ id, label, value }: Props) => {
   return (
     <IonItem
+      id={id}
       className="h-[54px]"
       lines="none"
-      onClick={openModal}
       style={{
         '--background': '#F4F5F7',
         '--border-radius': '12px',

--- a/src/modals/DatePicker.tsx
+++ b/src/modals/DatePicker.tsx
@@ -3,23 +3,24 @@ import { useState } from 'react';
 
 import ModalContainer from '.';
 
+import type { ModalProps } from '.';
+
 type Props = {
-  trigger: string;
   date?: string;
   setDate: (date: string) => void;
 };
 
-const DatePicker = ({ trigger, date, setDate }: Props) => {
+const DatePicker = ({ date, setDate, ...rest }: Props & ModalProps) => {
   const [selectedDate, setSelectedDate] = useState('');
 
   return (
     <ModalContainer
       title="생년월일을 입력해주세요"
       buttonText="확인"
-      trigger={trigger}
       initialBreakpoint={0.45}
       breakpoints={[0, 0.45]}
       onWillDismiss={() => setDate(selectedDate)}
+      {...rest}
     >
       <IonDatetime
         preferWheel

--- a/src/modals/DatePicker.tsx
+++ b/src/modals/DatePicker.tsx
@@ -4,16 +4,23 @@ import { useState } from 'react';
 import ModalContainer from '.';
 
 type Props = {
+  trigger: string;
   date?: string;
   setDate: (date: string) => void;
-  closeModal: () => void;
 };
 
-const DatePicker = ({ date, setDate, closeModal }: Props) => {
+const DatePicker = ({ trigger, date, setDate }: Props) => {
   const [selectedDate, setSelectedDate] = useState('');
 
   return (
-    <ModalContainer title="생년월일을 입력해주세요" closeModal={closeModal}>
+    <ModalContainer
+      title="생년월일을 입력해주세요"
+      buttonText="확인"
+      trigger={trigger}
+      initialBreakpoint={0.45}
+      breakpoints={[0, 0.45]}
+      onWillDismiss={() => setDate(selectedDate)}
+    >
       <IonDatetime
         preferWheel
         presentation="date"
@@ -23,16 +30,6 @@ const DatePicker = ({ date, setDate, closeModal }: Props) => {
           setSelectedDate(event.detail.value as string);
         }}
       />
-
-      <button
-        className="w-full button-primary button-lg mt-7"
-        onClick={() => {
-          setDate(selectedDate);
-          closeModal();
-        }}
-      >
-        확인
-      </button>
     </ModalContainer>
   );
 };

--- a/src/modals/PolicyAgreement.tsx
+++ b/src/modals/PolicyAgreement.tsx
@@ -4,14 +4,21 @@ import colors from '../theme/colors';
 import ModalContainer from '.';
 
 type Props = {
-  closeModal: () => void;
+  trigger: string;
 };
 
-const PolicyAgreement = ({ closeModal }: Props) => {
+const PolicyAgreement = ({ trigger }: Props) => {
   const router = useIonRouter();
 
   return (
-    <ModalContainer title="약관동의" closeModal={closeModal}>
+    <ModalContainer
+      trigger={trigger}
+      title="약관동의"
+      buttonText="회원가입 완료"
+      initialBreakpoint={0.4}
+      breakpoints={[0, 0.4]}
+      onClickButton={() => router.push('/sign-in/alarm')}
+    >
       <div className="flex flex-col gap-4 mt-4">
         <PolicyItem
           label={
@@ -31,13 +38,6 @@ const PolicyAgreement = ({ closeModal }: Props) => {
           개인정보처리방침에 동의합니다.
         </p>
       </div>
-
-      <button
-        className="w-full mt-3 button-primary button-lg"
-        onClick={() => router.push('/sign-in/alarm')}
-      >
-        회원가입 완료
-      </button>
     </ModalContainer>
   );
 };

--- a/src/modals/PolicyAgreement.tsx
+++ b/src/modals/PolicyAgreement.tsx
@@ -1,23 +1,19 @@
-import { IonCheckbox, useIonRouter } from '@ionic/react';
+import { IonCheckbox } from '@ionic/react';
 
 import colors from '../theme/colors';
 import ModalContainer from '.';
 
-type Props = {
-  trigger: string;
-};
+import type { ModalProps } from '.';
 
-const PolicyAgreement = ({ trigger }: Props) => {
-  const router = useIonRouter();
-
+const PolicyAgreement = ({ onClickButton, ...rest }: ModalProps) => {
   return (
     <ModalContainer
-      trigger={trigger}
       title="약관동의"
       buttonText="회원가입 완료"
       initialBreakpoint={0.4}
       breakpoints={[0, 0.4]}
-      onClickButton={() => router.push('/sign-in/alarm')}
+      onClickButton={onClickButton}
+      {...rest}
     >
       <div className="flex flex-col gap-4 mt-4">
         <PolicyItem

--- a/src/modals/SelectGender.tsx
+++ b/src/modals/SelectGender.tsx
@@ -5,24 +5,25 @@ import { useState } from 'react';
 import CheckIcon from '../assets/svgs/check.svg';
 import ModalContainer from '.';
 
+import type { ModalProps } from '.';
+
 const genders = ['여성', '남성', '선택안함'];
 
 type Props = {
-  trigger: string;
   setGender: (value: string) => void;
 };
 
-const SelectGender = ({ trigger, setGender }: Props) => {
+const SelectGender = ({ setGender, ...rest }: ModalProps & Props) => {
   const [selectedGender, setSelectedGender] = useState('');
 
   return (
     <ModalContainer
-      trigger={trigger}
       title="성별을 선택하세요"
       buttonText="확인"
       initialBreakpoint={0.4}
       breakpoints={[0, 0.4]}
       onWillDismiss={() => setGender(selectedGender)}
+      {...rest}
     >
       <IonList onClick={(event: any) => setSelectedGender(event.target.innerText as string)}>
         {genders.map((gender) => (

--- a/src/modals/SelectGender.tsx
+++ b/src/modals/SelectGender.tsx
@@ -8,15 +8,22 @@ import ModalContainer from '.';
 const genders = ['여성', '남성', '선택안함'];
 
 type Props = {
+  trigger: string;
   setGender: (value: string) => void;
-  closeModal: () => void;
 };
 
-const SelectGender = ({ setGender, closeModal }: Props) => {
+const SelectGender = ({ trigger, setGender }: Props) => {
   const [selectedGender, setSelectedGender] = useState('');
 
   return (
-    <ModalContainer title="성별을 선택하세요" closeModal={closeModal}>
+    <ModalContainer
+      trigger={trigger}
+      title="성별을 선택하세요"
+      buttonText="확인"
+      initialBreakpoint={0.4}
+      breakpoints={[0, 0.4]}
+      onWillDismiss={() => setGender(selectedGender)}
+    >
       <IonList onClick={(event: any) => setSelectedGender(event.target.innerText as string)}>
         {genders.map((gender) => (
           <IonItem key={gender}>
@@ -31,15 +38,6 @@ const SelectGender = ({ setGender, closeModal }: Props) => {
           </IonItem>
         ))}
       </IonList>
-      <button
-        className="w-full mt-5 button-primary button-lg"
-        onClick={() => {
-          setGender(selectedGender);
-          closeModal();
-        }}
-      >
-        확인
-      </button>
     </ModalContainer>
   );
 };

--- a/src/modals/SelectRegion.tsx
+++ b/src/modals/SelectRegion.tsx
@@ -6,11 +6,9 @@ import allRegions from '../constants/region';
 import useRegionStore from '../stores/user';
 import ModalContainer from '.';
 
-type Props = {
-  trigger: string;
-};
+import type { ModalProps } from '.';
 
-const SelectRegion = ({ trigger }: Props) => {
+const SelectRegion = (props: ModalProps) => {
   const setRegion = useRegionStore((state) => state.setRegion);
 
   const [regions, setRegions] = useState(() =>
@@ -78,12 +76,12 @@ const SelectRegion = ({ trigger }: Props) => {
 
   return (
     <ModalContainer
-      trigger={trigger}
       title="출신 국가를 선택하세요"
       buttonText="선택"
       initialBreakpoint={0.95}
       breakpoints={[0, 0.95]}
       onClickButton={() => setRegion(selectedRegion)}
+      {...props}
     >
       <div className="h-11 bg-gray1.5 rounded-lg px-4 w-full justify-between items-center flex my-4">
         <IonInput

--- a/src/modals/SelectRegion.tsx
+++ b/src/modals/SelectRegion.tsx
@@ -7,10 +7,10 @@ import useRegionStore from '../stores/user';
 import ModalContainer from '.';
 
 type Props = {
-  closeModal: () => void;
+  trigger: string;
 };
 
-const SelectRegion = ({ closeModal }: Props) => {
+const SelectRegion = ({ trigger }: Props) => {
   const setRegion = useRegionStore((state) => state.setRegion);
 
   const [regions, setRegions] = useState(() =>
@@ -77,7 +77,14 @@ const SelectRegion = ({ closeModal }: Props) => {
   };
 
   return (
-    <ModalContainer title="출신 국가를 선택하세요" closeModal={closeModal}>
+    <ModalContainer
+      trigger={trigger}
+      title="출신 국가를 선택하세요"
+      buttonText="선택"
+      initialBreakpoint={0.95}
+      breakpoints={[0, 0.95]}
+      onClickButton={() => setRegion(selectedRegion)}
+    >
       <div className="h-11 bg-gray1.5 rounded-lg px-4 w-full justify-between items-center flex my-4">
         <IonInput
           className="font-body1 text-gray8"
@@ -104,17 +111,6 @@ const SelectRegion = ({ closeModal }: Props) => {
           ))}
         </IonList>
       </section>
-
-      <button
-        className="w-full button-primary button-lg"
-        disabled={!selectedRegion}
-        onClick={() => {
-          setRegion(selectedRegion);
-          closeModal();
-        }}
-      >
-        선택
-      </button>
     </ModalContainer>
   );
 };

--- a/src/modals/index.tsx
+++ b/src/modals/index.tsx
@@ -1,27 +1,51 @@
-import { IonIcon, IonText } from '@ionic/react';
+/* eslint-disable @typescript-eslint/no-misused-promises */
+import { IonIcon, IonModal, IonText } from '@ionic/react';
+import { useRef, type ComponentProps, type PropsWithChildren } from 'react';
 
 import CloseIcon from '../assets/svgs/close.svg';
 
-import type { PropsWithChildren } from 'react';
-
 type Props = {
+  trigger: string;
   title: string;
-  closeModal: () => void;
+  buttonText: string;
+  onClickButton?: () => void;
 };
 
-const ModalContainer = ({ title, children, closeModal }: PropsWithChildren<Props>) => {
+const ModalContainer = ({
+  trigger,
+  title,
+  buttonText,
+  onClickButton,
+  children,
+  ...rest
+}: PropsWithChildren<Props & ComponentProps<typeof IonModal>>) => {
+  // eslint-disable-next-line no-undef
+  const modalRef = useRef<HTMLIonModalElement>(null);
+
   return (
-    <div className="relative p-4 pt-10 mb-28">
-      <IonIcon
-        className="absolute svg-lg stroke-gray7 top-4 right-4"
-        src={CloseIcon}
-        onClick={closeModal}
-      />
+    <IonModal ref={modalRef} trigger={trigger} {...rest}>
+      <div className="relative p-4 pt-10 mb-28">
+        <IonIcon
+          className="absolute svg-lg stroke-gray7 top-4 right-4"
+          src={CloseIcon}
+          onClick={() => modalRef.current?.dismiss()}
+        />
 
-      <IonText className="mb-5 font-headline2 text-gray8">{title}</IonText>
+        <IonText className="mb-5 font-headline2 text-gray8">{title}</IonText>
 
-      {children}
-    </div>
+        {children}
+
+        <button
+          className="w-full button-primary button-lg"
+          onClick={async () => {
+            onClickButton && onClickButton();
+            await modalRef.current?.dismiss();
+          }}
+        >
+          {buttonText}
+        </button>
+      </div>
+    </IonModal>
   );
 };
 

--- a/src/modals/index.tsx
+++ b/src/modals/index.tsx
@@ -4,11 +4,16 @@ import { useRef, type ComponentProps, type PropsWithChildren } from 'react';
 
 import CloseIcon from '../assets/svgs/close.svg';
 
-type Props = {
+export type ModalProps = {
   trigger: string;
+  onClickButton?: () => void;
+  onWillDismiss?: () => void;
+  onDidDismiss?: () => void;
+};
+
+type Props = {
   title: string;
   buttonText: string;
-  onClickButton?: () => void;
 };
 
 const ModalContainer = ({
@@ -18,7 +23,7 @@ const ModalContainer = ({
   onClickButton,
   children,
   ...rest
-}: PropsWithChildren<Props & ComponentProps<typeof IonModal>>) => {
+}: PropsWithChildren<ModalProps & Props & ComponentProps<typeof IonModal>>) => {
   // eslint-disable-next-line no-undef
   const modalRef = useRef<HTMLIonModalElement>(null);
 

--- a/src/pages/region/Region.tsx
+++ b/src/pages/region/Region.tsx
@@ -1,5 +1,5 @@
-import { IonIcon, IonImg, IonModal, IonText, useIonRouter } from '@ionic/react';
-import { useEffect, useState } from 'react';
+import { IonIcon, IonImg, IonText, useIonRouter } from '@ionic/react';
+import { useEffect } from 'react';
 
 import GlobeIcon from '../../assets/svgs/globe.svg';
 import LogoWithLabelImage from '../../assets/images/logo-with-label.png';
@@ -8,13 +8,13 @@ import useRegionStore from '../../stores/user';
 
 const LoginLanding = () => {
   const router = useIonRouter();
-  const { region, resetRegion } = useRegionStore((state) => state);
-
-  const [openModal, setOpenModal] = useState(false);
+  const { region } = useRegionStore((state) => state);
 
   useEffect(() => {
-    resetRegion();
-  }, [resetRegion]);
+    if (region['2digitCode']) {
+      router.push('/');
+    }
+  }, [region, router]);
 
   return (
     <div className="relative flex flex-col items-center justify-center h-full gap-6">
@@ -22,7 +22,7 @@ const LoginLanding = () => {
 
       <div
         className="flex items-center justify-between p-4 bg-gray1.5 rounded-xl w-[15rem] cursor-pointer mb-[5rem]"
-        onClick={() => setOpenModal(true)}
+        id="region-modal"
       >
         <IonText className="text-gray5 font-body1">출신 국가를 선택하세요</IonText>
         <IonIcon className="svg-lg" src={GlobeIcon} />
@@ -30,17 +30,7 @@ const LoginLanding = () => {
 
       <IonImg className="absolute bottom-4 w-[6.75rem] h-[1.875rem]" src={LogoWithLabelImage} />
 
-      <IonModal
-        isOpen={openModal}
-        initialBreakpoint={0.95}
-        breakpoints={[0, 0.95]}
-        onDidDismiss={() => {
-          setOpenModal(false);
-          !!region['2digitCode'] && router.push('/', 'root', 'replace');
-        }}
-      >
-        <SelectRegion closeModal={() => setOpenModal(false)} />
-      </IonModal>
+      <SelectRegion trigger="region-modal" />
     </div>
   );
 };

--- a/src/pages/sign-in/PhoneAuth.tsx
+++ b/src/pages/sign-in/PhoneAuth.tsx
@@ -1,4 +1,4 @@
-import { IonModal, IonText, useIonRouter } from '@ionic/react';
+import { IonText, useIonRouter } from '@ionic/react';
 import { useState } from 'react';
 
 import Header from '../../components/Header';
@@ -11,7 +11,6 @@ const PhoneAuth = () => {
   const router = useIonRouter();
   const region = useRegionStore((state) => state.region);
 
-  const [openModal, setOpenModal] = useState(false);
   const [phoneNumber, setPhoneNumber] = useState('');
   const [authCode, setAuthCode] = useState('');
 
@@ -21,9 +20,9 @@ const PhoneAuth = () => {
 
       <div className="flex flex-col gap-2 px-4 mt-5">
         <SelectInput
+          id="region-modal"
           label="국가/지역"
           value={`${region.CountryNameKR} (+${String(region.ISONumbericCode).padStart(2, '0')})`}
-          openModal={() => setOpenModal(true)}
         />
 
         <div className="flex items-center gap-2">
@@ -57,14 +56,7 @@ const PhoneAuth = () => {
         </div>
       </div>
 
-      <IonModal
-        isOpen={openModal}
-        initialBreakpoint={0.95}
-        breakpoints={[0, 0.95]}
-        onDidDismiss={() => setOpenModal(false)}
-      >
-        <SelectRegion closeModal={() => setOpenModal(false)} />
-      </IonModal>
+      <SelectRegion trigger="region-modal" />
     </>
   );
 };

--- a/src/pages/sign-in/UserInfo.tsx
+++ b/src/pages/sign-in/UserInfo.tsx
@@ -1,4 +1,4 @@
-import { IonContent, IonModal, IonText } from '@ionic/react';
+import { IonContent, IonText } from '@ionic/react';
 import { useState } from 'react';
 
 import Header from '../../components/Header';
@@ -17,10 +17,6 @@ const UserInfo = () => {
   const [birth, setBirth] = useState('');
   const [gender, setGender] = useState('');
 
-  const [openDateModal, setOpenDateModal] = useState(false);
-  const [openGenderModal, setOpenGenderModal] = useState(false);
-  const [openPolicyModal, setOpenPolicyModal] = useState(false);
-
   return (
     <IonContent className="relative h-full">
       <Header type="back" />
@@ -38,53 +34,28 @@ const UserInfo = () => {
 
         <div className="flex flex-col gap-2 mb-9">
           <SelectInput
+            id="date-modal"
             label="생년월일(YYYY/MM/DD)"
             value={birth.split('T')[0].replaceAll('-', '/')}
-            openModal={() => setOpenDateModal(true)}
           />
           <IonText className="pl-1 font-caption2 text-gray6">
             피플히어에 가입하려면 만 18세 이상이어야 해요.
           </IonText>
         </div>
 
-        <SelectInput label="성별" value={gender} openModal={() => setOpenGenderModal(true)} />
+        <SelectInput id="gender-modal" label="성별" value={gender} />
 
         <Footer>
-          <button
-            className="w-full button-primary button-lg"
-            onClick={() => setOpenPolicyModal(true)}
-          >
+          <button id="policy-modal" className="w-full button-primary button-lg">
             계속
           </button>
         </Footer>
       </div>
 
-      <IonModal
-        isOpen={openDateModal}
-        initialBreakpoint={0.45}
-        breakpoints={[0, 0.45]}
-        onDidDismiss={() => setOpenDateModal(false)}
-      >
-        <DatePicker setDate={setBirth} closeModal={() => setOpenDateModal(false)} />
-      </IonModal>
-
-      <IonModal
-        isOpen={openGenderModal}
-        initialBreakpoint={0.4}
-        breakpoints={[0, 0.4]}
-        onDidDismiss={() => setOpenGenderModal(false)}
-      >
-        <SelectGender setGender={setGender} closeModal={() => setOpenGenderModal(false)} />
-      </IonModal>
-
-      <IonModal
-        trigger="policy-modal"
-        initialBreakpoint={0.4}
-        breakpoints={[0, 0.4]}
-        onDidDismiss={() => setOpenPolicyModal(false)}
-      >
-        <PolicyAgreement closeModal={() => setOpenPolicyModal(false)} />
-      </IonModal>
+      {/* Modals */}
+      <DatePicker trigger="date-modal" setDate={setBirth} />
+      <SelectGender trigger="gender-modal" setGender={setGender} />
+      <PolicyAgreement trigger="policy-modal" />
     </IonContent>
   );
 };

--- a/src/pages/sign-in/UserInfo.tsx
+++ b/src/pages/sign-in/UserInfo.tsx
@@ -1,4 +1,4 @@
-import { IonContent, IonText } from '@ionic/react';
+import { IonContent, IonText, useIonRouter } from '@ionic/react';
 import { useState } from 'react';
 
 import Header from '../../components/Header';
@@ -11,9 +11,10 @@ import SelectGender from '../../modals/SelectGender';
 import PolicyAgreement from '../../modals/PolicyAgreement';
 
 const UserInfo = () => {
+  const router = useIonRouter();
+
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
-
   const [birth, setBirth] = useState('');
   const [gender, setGender] = useState('');
 
@@ -55,7 +56,7 @@ const UserInfo = () => {
       {/* Modals */}
       <DatePicker trigger="date-modal" setDate={setBirth} />
       <SelectGender trigger="gender-modal" setGender={setGender} />
-      <PolicyAgreement trigger="policy-modal" />
+      <PolicyAgreement trigger="policy-modal" onClickButton={() => router.push('/sign-in/alarm')} />
     </IonContent>
   );
 };

--- a/src/tabs/ProfileTab.tsx
+++ b/src/tabs/ProfileTab.tsx
@@ -1,7 +1,11 @@
 import { IonContent, IonHeader, IonPage, IonText, IonTitle, IonToolbar } from '@ionic/react';
 import { Link } from 'react-router-dom';
 
+import useRegionStore from '../stores/user';
+
 const ProfileTab = () => {
+  const reset = useRegionStore((state) => state.resetRegion);
+
   return (
     <IonPage>
       <IonHeader>
@@ -13,6 +17,16 @@ const ProfileTab = () => {
         <Link to="/login/region">
           <IonText>goto login</IonText>
         </Link>
+
+        <button
+          className="button-primary button-md"
+          onClick={() => {
+            console.log('reset');
+            reset();
+          }}
+        >
+          reset region
+        </button>
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
모달 사용 부분을 추상화하고 모달의 feature들의 책임을 페이지에서 모달로 이관

### AS-IS
- 기존 사용은 페이지레벨에서 IonModal로 모달의 children을 감싸던 형태
- 모달의 open 상태 또한 페이지 레벨에서 관리했음
```jsx
<IonModal
  isOpen={modalOpen}
  initialBreakPoint={0.5}
  breakpoints={[0, 0,4]}
>
  {children}
</IonModal>
```

### TO-BE
페이지 레벨에서는 모달의 상태를 신경쓰지 않고, 모달의 상태가 변화했을 때의 동작만 정의할 수 있도록 추상화
- 모달을 IonModal로 일일이 감싸지 않고, 해당 모달을 선언만
- 선언과 trigger만 전달하고, 모달의 상태가 변할 때(버튼 클릭, 모달이 닫힐 때)의 액션만 전달할 수 있도록 변경

**사용부**
```jsx
<DatePicker trigger="date-modal" onDidDismiss={() => { /** do something */ }} />
```

**선언부**
- 여기에 기존에 페이지에서 IonModal로 감쌌던 부분을 옮겼습니다.
```jsx
// DatePicker.tsx
<ModalContainer
  title="생년월일을 입력해주세요"
  buttonText="확인"
  initialBreakpoint={0.45}
  breakpoints={[0, 0.45]}
  onWillDismiss={() => setDate(selectedDate)}
  {...rest}
>
  {children}
</ModalContainer>
```
